### PR TITLE
Expose a way to override the application key. 

### DIFF
--- a/BugsplatMac/BugsplatStartupManager.h
+++ b/BugsplatMac/BugsplatStartupManager.h
@@ -68,6 +68,11 @@
 @property (nonatomic, assign) NSTimeInterval expirationTimeInterval;
 
 /**
+ *  Application key used to load specific support response
+ */
+@property (nonatomic, assign, nullable) NSString *applicationKey;
+
+/**
  *  Represents user's full name
  */
 @property (nonatomic, copy, nullable) NSString *userName;

--- a/BugsplatMac/BugsplatStartupManager.m
+++ b/BugsplatMac/BugsplatStartupManager.m
@@ -104,6 +104,11 @@ NSString *const kHockeyIdentifierPlaceholder = @"b0cf675cb9334a3e96eda0764f95e38
     [[[BITHockeyManager sharedHockeyManager] crashManager] setAutoSubmitCrashReport:self.autoSubmitCrashReport];
 }
 
+- (void)setAppKey:(NSString *)applicationKey
+{
+    _applicationKey = applicationKey;
+}
+
 - (void)setUserName:(NSString *)userName
 {
     _userName = userName;
@@ -146,6 +151,10 @@ NSString *const kHockeyIdentifierPlaceholder = @"b0cf675cb9334a3e96eda0764f95e38
 
 - (NSString *)applicationKeyForCrashManager:(BITCrashManager *)crashManager signal:(NSString *)signal exceptionName:(NSString *)exceptionName exceptionReason:(NSString *)exceptionReason
 {
+    if (_applicationKey) {
+        return _applicationKey;
+    }
+    
     if ([_delegate respondsToSelector:@selector(applicationKeyForBugsplatStartupManager:signal:exceptionName:exceptionReason:)])
     {
         return [_delegate applicationKeyForBugsplatStartupManager:self signal:signal exceptionName:exceptionName exceptionReason:exceptionReason];


### PR DESCRIPTION
This allows BugSplat to return a different version of the support response depending on the value of the application key.