### PR TITLE
Changed authentication to use /api/authenticatev3.php

### DIFF
--- a/upload-archive-cl.sh
+++ b/upload-archive-cl.sh
@@ -74,7 +74,7 @@ echo "Signing into bugsplat and storing session cookie for use in upload" >> $LO
 
 COOKIEPATH="/tmp/bugsplat-cookie.txt"
 rm "${COOKIEPATH}"
-curl -b "${COOKIEPATH}" -c "${COOKIEPATH}" --data-urlencode "currusername=${BUGSPLAT_USER}" --data-urlencode "currpasswd=${BUGSPLAT_PASS}" "${BUGSPLAT_SERVER_URL}/browse/login.php"
+curl -b "${COOKIEPATH}" -c "${COOKIEPATH}" --data-urlencode "email=${BUGSPLAT_USER}" --data-urlencode "password=${BUGSPLAT_PASS}" "${BUGSPLAT_SERVER_URL}/api/authenticatev3.php"
 
 echo "Uploading /tmp/${PRODUCT_NAME}.xcarchive.zip to ${UPLOAD_URL}" >> $LOG 2>&1
 

--- a/upload-archive.sh
+++ b/upload-archive.sh
@@ -65,10 +65,10 @@ echo "UUID found: ${UUID_CMD_OUT}" > $LOG 2>&1
 echo "Signing into bugsplat and storing session cookie for use in upload" >> $LOG 2>&1
 
 COOKIEPATH="/tmp/bugsplat-cookie.txt"
-LOGIN_URL="${BUGSPLAT_SERVER_URL}/browse/login.php"
+LOGIN_URL="${BUGSPLAT_SERVER_URL}/api/authenticatev3.php"
 echo "Login URL: ${LOGIN_URL}"
 rm "${COOKIEPATH}"
-curl -b "${COOKIEPATH}" -c "${COOKIEPATH}" --data-urlencode "currusername=${BUGSPLAT_USER}" --data-urlencode "currpasswd=${BUGSPLAT_PASS}" "${LOGIN_URL}"
+curl -b "${COOKIEPATH}" -c "${COOKIEPATH}" --data-urlencode "email=${BUGSPLAT_USER}" --data-urlencode "password=${BUGSPLAT_PASS}" "${LOGIN_URL}"
 
 echo "Uploading /tmp/${PRODUCT_NAME}.xcarchive.zip to ${UPLOAD_URL}" >> $LOG 2>&1
 

--- a/upload-symbols.sh
+++ b/upload-symbols.sh
@@ -115,10 +115,10 @@ echo "UUID found: ${UUID_CMD_OUT}"
 echo "Signing into bugsplat and storing session cookie for use in upload"
 
 COOKIEPATH="/tmp/bugsplat-cookie.txt"
-LOGIN_URL="${BUGSPLAT_SERVER_URL}/browse/login.php"
+LOGIN_URL="${BUGSPLAT_SERVER_URL}/api/authenticatev3.php"
 echo "Login URL: ${LOGIN_URL}"
 rm "${COOKIEPATH}"
-curl -b "${COOKIEPATH}" -c "${COOKIEPATH}" --data-urlencode "currusername=${BUGSPLAT_USER}" --data-urlencode "currpasswd=${BUGSPLAT_PASS}" "${LOGIN_URL}"
+curl -b "${COOKIEPATH}" -c "${COOKIEPATH}" --data-urlencode "email=${BUGSPLAT_USER}" --data-urlencode "password=${BUGSPLAT_PASS}" "${LOGIN_URL}"
 
 echo "Uploading ${FILE} to ${UPLOAD_URL}"
 


### PR DESCRIPTION
### Description

Sander from Resolume reports sporadic 500 errors from the plCrashReporter/symbol endpoint.  We're not sure what's causing this.  However, changing authentication so that we don't redirect to the /v2  folder which doesn't exist on the crash analyzers seems like a good start.

Fixes #18 

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
