### PR TITLE
chore: add swift-pm info

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "BugsplatMac",
+    products: [
+        .library(
+            name: "BugsplatMac",
+            targets: ["BugsplatMac"]),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "BugsplatMac",
+            url: "https://github.com/BugSplat-Git/BugSplat-macOS/releases/download/1.1.5/BugsplatMac.xcframework.zip",
+            checksum: "132c951b438a82f18aa5e02e7c249c8db5dc07cd130f4448df2a572781199cb8"),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ BugsplatMac supports multiple methods for installing the library in a project.
 
 ### Swift Package Manager
 
-We recommend you install BugSplat via Swift Package Manager. You can add BugsplatMac as a dependency in the Swift Packages configuration in your Xcode project by pointing to <https://github.com/BugSplat-Git/BugSplatMac-SP>.
+We recommend you install BugSplat via Swift Package Manager. You can add `BugsplatMac` as a dependency in the Swift Packages configuration in your Xcode project by pointing to <https://github.com/BugSplat-Git/bugsplat-macos>.
 
 ### CocoaPods, Carthage, or Manual Installation
 


### PR DESCRIPTION
### Description

Allow users to install BugSplatMac via Swift Package Manager. This allows us to retire redundant repo [BugSplatMac-SP.](https://github.com/BugSplat-Git/BugSplatMac-SP)

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
